### PR TITLE
Feature/Add deployment step for self-hosted runner in Docker workflow

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -39,4 +39,27 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ github.sha }}
+
+      - name: Deploy to self-hosted runner
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+          IMAGE=ghcr.io/${{ github.repository }}:${{ github.sha }}
+          LATEST=ghcr.io/${{ github.repository }}:latest
+
+          echo "Pulling image $IMAGE (fallback to latest)"
+          if ! docker pull "$IMAGE"; then
+            docker pull "$LATEST"
+            IMAGE="$LATEST"
+          fi
+
+          echo "Stopping existing container if present"
+          docker rm -f basis-redis || true
+
+          echo "Running container basis-redis"
+          docker run -d \
+            --name basis-redis \
+            --restart unless-stopped \
+            -p 6379:6379 \
+            "$IMAGE"
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -47,6 +47,9 @@ jobs:
           IMAGE=ghcr.io/${{ github.repository }}:${{ github.sha }}
           LATEST=ghcr.io/${{ github.repository }}:latest
 
+          echo "Logging in to GitHub Container Registry"
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
           echo "Pulling image $IMAGE (fallback to latest)"
           if ! docker pull "$IMAGE"; then
             docker pull "$LATEST"

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -62,4 +62,3 @@ jobs:
             --restart unless-stopped \
             -p 6379:6379 \
             "$IMAGE"
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -60,5 +60,6 @@ jobs:
           docker run -d \
             --name basis-redis \
             --restart unless-stopped \
+            -v /var/lib/basis-redis-data:/data \
             -p 6379:6379 \
             "$IMAGE"


### PR DESCRIPTION
This pull request adds a deployment step to the `.github/workflows/docker-deploy.yml` workflow, enabling automatic deployment to a self-hosted runner when changes are pushed to the `main` branch or a version tag. The new step pulls the latest Docker image, stops any running container, and starts a new one.

Deployment automation:

* Added a "Deploy to self-hosted runner" job step that runs when pushing to `main` or a version tag, automating the process of pulling the Docker image, stopping any existing `basis-redis` container, and starting a new one with the latest image.